### PR TITLE
Added laravel 8 support in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^9.0",
+        "laravel/framework": "^8.0|^9.0",
         "laravel/nova": "^4.0"
     },
     "autoload": {


### PR DESCRIPTION
Hi Alexwenzel I'm currently working on a Laravel Nova project and do not see a reason for this package's latest version to only be compatible with Laravel 9.
I also tested it with Laravel 8 and I see no problems except for Actions in Nova, they do not work with v1.0 which would get fixed if I could use your latest version of this package.