### PR TITLE
Nova action's `validateFields` not called due overridden `ActionReque…

### DIFF
--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -5,6 +5,7 @@ namespace Alexwenzel\DependencyContainer\Http\Controllers;
 use Alexwenzel\DependencyContainer\Http\Requests\ActionRequest;
 use Laravel\Nova\Http\Requests\ActionRequest as NovaActionRequest;
 use Laravel\Nova\Http\Controllers\ActionController as NovaActionController;
+use Alexwenzel\DependencyContainer\ActionHasDependencies;
 
 class ActionController extends NovaActionController
 {
@@ -16,7 +17,11 @@ class ActionController extends NovaActionController
      */
     public function store(NovaActionRequest $request)
     {
-        $request = ActionRequest::createFrom($request);
+        $action = $request->action();
+
+        if (in_array(ActionHasDependencies::class, class_uses_recursive($action))) {
+            $request = ActionRequest::createFrom($request);
+        }
 
         return parent::store($request);
     }


### PR DESCRIPTION
Checking if the required trait is used, and only then overiding the `ActionRequest` with the custom one