### PR TITLE
Handle BackedEnum

### DIFF
--- a/src/DependencyContainer.php
+++ b/src/DependencyContainer.php
@@ -337,7 +337,7 @@ class DependencyContainer extends Field
                 && !array_key_exists('notin', $dependency)
                 && !array_key_exists('nullOrZero', $dependency)) {
                 if ($dependency['value'] instanceof BackedEnum) {
-                    if ($dependency['value']->tryFrom($request->get($dependency['property']))) {
+                    if ($dependency['value']->value == $request->get($dependency['property'])) {
                         $satisfiedCounts++;
                     }
                 } elseif ($dependency['value'] == $request->get($dependency['property'])) {

--- a/src/DependencyContainer.php
+++ b/src/DependencyContainer.php
@@ -4,6 +4,7 @@ namespace Alexwenzel\DependencyContainer;
 
 use Aqjw\MedialibraryField\Fields\Medialibrary;
 use Aqjw\MedialibraryField\Fields\Support\MediaCollectionRules;
+use BackedEnum;
 use Illuminate\Support\Arr;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Http\Requests\NovaRequest;
@@ -334,9 +335,14 @@ class DependencyContainer extends Field
             if (array_key_exists('value', $dependency)
                 && !array_key_exists('in', $dependency)
                 && !array_key_exists('notin', $dependency)
-                && !array_key_exists('nullOrZero', $dependency)
-                && $dependency['value'] == $request->get($dependency['property'])) {
-                $satisfiedCounts++;
+                && !array_key_exists('nullOrZero', $dependency)) {
+                if ($dependency['value'] instanceof BackedEnum) {
+                    if ($dependency['value']->tryFrom($request->get($dependency['property']))) {
+                        $satisfiedCounts++;
+                    }
+                } elseif ($dependency['value'] == $request->get($dependency['property'])) {
+                    $satisfiedCounts++;
+                }
             }
         }
 


### PR DESCRIPTION
When doing an `==` comparison on a BackedEnum it compares the objects, not the value.

This updates the code to identify BackedEnum objects and use the `value` property for comparison instead of the object.