### PR TITLE
Fix incompatible method declaration

### DIFF
--- a/src/DependencyContainer.php
+++ b/src/DependencyContainer.php
@@ -178,7 +178,7 @@ class DependencyContainer extends Field
      * @param mixed $resource
      * @param null  $attribute
      */
-    public function resolveForDisplay($resource, $attribute = null)
+    public function resolveForDisplay($resource, $attribute = null): void
     {
         foreach ($this->meta['fields'] as $field) {
             $field->resolveForDisplay($resource);
@@ -247,7 +247,7 @@ class DependencyContainer extends Field
      * @param string $attribute
      * @return array|mixed
      */
-    public function resolve($resource, $attribute = null)
+    public function resolve($resource, $attribute = null): void
     {
         foreach ($this->meta['fields'] as $field) {
             $field->resolve($resource, $attribute);
@@ -418,7 +418,7 @@ class DependencyContainer extends Field
      * @param NovaRequest $request
      * @return array
      */
-    public function getRules(NovaRequest $request)
+    public function getRules(NovaRequest $request): array
     {
         return $this->getSituationalRulesSet($request);
     }
@@ -429,7 +429,7 @@ class DependencyContainer extends Field
      * @param NovaRequest $request
      * @return array|string
      */
-    public function getCreationRules(NovaRequest $request)
+    public function getCreationRules(NovaRequest $request): array
     {
         $fieldsRules = $this->getSituationalRulesSet($request, 'getCreationRules');
 
@@ -445,7 +445,7 @@ class DependencyContainer extends Field
      * @param NovaRequest $request
      * @return array
      */
-    public function getUpdateRules(NovaRequest $request)
+    public function getUpdateRules(NovaRequest $request): array
     {
         $fieldsRules = $this->getSituationalRulesSet($request, 'getUpdateRules');
 

--- a/src/HasDependencies.php
+++ b/src/HasDependencies.php
@@ -15,7 +15,7 @@ trait HasDependencies
      * @param  NovaRequest  $request
      * @return FieldCollection
      */
-    public function availableFields(NovaRequest $request)
+    public function availableFields(NovaRequest $request): FieldCollection
     {
         $method = $this->fieldsMethod($request);
 

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -15,7 +15,7 @@ class ActionController extends NovaActionController
      * @param  \Laravel\Nova\Http\Requests\ActionRequest  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(NovaActionRequest $request)
+    public function store(NovaActionRequest $request): mixed
     {
         $action = $request->action();
 


### PR DESCRIPTION
In Laravel 11 with Nova 5 the following error occurred:

> Declaration of Alexwenzel\DependencyContainer\HasDependencies::availableFields(Laravel\Nova\Http\Requests\NovaRequest $request) must be compatible with Laravel\Nova\Resource::availableFields(Laravel\Nova\Http\Requests\NovaRequest $request): Laravel\Nova\Fields\FieldCollection

I fixed that by adding the missing return type.